### PR TITLE
fix: compatibility with Ruby 3.2.2

### DIFF
--- a/yeetwords.rb
+++ b/yeetwords.rb
@@ -1830,7 +1830,7 @@ def file_2_arr(filename, remove_blanks = false)
   # Items are purposely not unique here; if unique is desired this
   # must be done afterwards (using Ruby's uniq method)
   arrname = Array.new
-  if File.exists?(filename) then
+  if File.exist?(filename) then
     IO.foreach(filename){|theline|
       if remove_blanks == false then
         arrname << theline.chomp.strip


### PR DESCRIPTION
now using File.exist? method instead of the previous File.exists? method (deprecated in 3.x.y versions of Ruby - not sure exactly which 3.x.y version this happened, but between 3.0 and 3.2.2). Backwards compatible.